### PR TITLE
transition animation fix

### DIFF
--- a/src/main/java/org/vaadin/virkki/carousel/client/widget/gwt/AnimatedCarouselWidget.xtend
+++ b/src/main/java/org/vaadin/virkki/carousel/client/widget/gwt/AnimatedCarouselWidget.xtend
@@ -10,6 +10,7 @@ import com.google.gwt.user.client.ui.VerticalPanel
 import com.google.gwt.user.client.ui.Widget
 import java.util.List
 import com.google.gwt.user.client.Window
+import com.google.gwt.core.client.Scheduler
 
 abstract class AnimatedCarouselWidget extends CarouselWidgetBase {
 
@@ -30,6 +31,9 @@ abstract class AnimatedCarouselWidget extends CarouselWidgetBase {
 
 	@Property CarouselLoadMode loadMode
 	int transitionDuration = 1000
+
+	double scheduledTargetPosition;
+	boolean childPanelPositionSchedulerActive = false;
 
 	override setWidgets(List<Widget> _widgets) {
 		if (!_widgets.isEmpty) {
@@ -92,11 +96,21 @@ abstract class AnimatedCarouselWidget extends CarouselWidgetBase {
 
 			animTargetPosition = index * -measure - currentMargin
 			if (!animationFallback) {
-				setChildPanelPosition(animTargetPosition)
+				scheduleSetChildPanelPosition(animTargetPosition)
 			}
 
 			anim.run(transitionDuration)
 			runTimer.schedule(transitionDuration)
+		}
+	}
+
+	def private scheduleSetChildPanelPosition(double targetPosition) {
+		scheduledTargetPosition = targetPosition;
+		if (!childPanelPositionSchedulerActive) {
+			Scheduler::get().scheduleDeferred([ |
+				setChildPanelPosition(scheduledTargetPosition)
+				childPanelPositionSchedulerActive = false;
+			])
 		}
 	}
 
@@ -171,7 +185,7 @@ abstract class AnimatedCarouselWidget extends CarouselWidgetBase {
 
 		childPanel.forEach[setPixelSize(width, height)]
 
-		setChildPanelPosition(index * -measure - currentMargin)
+		scheduleSetChildPanelPosition(index * -measure - currentMargin)
 		updateChildPanelMargin
 
 		onUpdate(0)


### PR DESCRIPTION
Fixes animation when scrollToPanelIndex,
and setCarouselSize called in same event loop

Bug can be reproduced, when you add a new component, and scroll to it in one round, in a fullsized carousel.

<pre>
HorizontalCarousel c = new HorizontalCarousel();
c.setSizeFull();
c.addComponent(firstchild);
....
....//later in an event listener
c.addComponent(secondchild);
c.requestWidgets(2); 
c.scroll(1);
</pre>

In this case no animation occured. I've not tested fallback mode. I think should work.

Full testcode can be found in my 'testbed' branch, if you are interested.
